### PR TITLE
publishDir Fix

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -29,15 +29,20 @@ include { unpack; unpackBiom } from './modules/unpack.nf'
 // Main workflow
 //---------------------------------------------------------------------------------
 workflow {
-    loadInitialOntology | loadEntityGraph | loadDatasetSpecificAnnotationPropertiesAndGraphs | dumpFiles
+    loadInitialOntology()
+    loadEntityGraph(loadInitialOntology.out, params.studyDirectory, params.webDisplayOntologyFile)
+    loadDatasetSpecificAnnotationPropertiesAndGraphs(loadEntityGraph.out)
+    dumpFiles(loadDatasetSpecificAnnotationPropertiesAndGraphs.out)
 }
 
 workflow loadEntityGraphEntry {
-    loadInitialOntology | loadEntityGraph;
+    loadInitialOntology()
+    loadEntityGraph(loadInitialOntology.out, params.studyDirectory, params.webDisplayOntologyFile)
 }
 
 workflow loadDatasetSpecificAnnotationPropertiesAndGraphsEntry {
-    loadDatasetSpecificAnnotationPropertiesAndGraphs(Channel.value("READY!")) | dumpFiles
+    loadDatasetSpecificAnnotationPropertiesAndGraphs(Channel.value("READY!"))
+    dumpFiles(loadDatasetSpecificAnnotationPropertiesAndGraphs.out)
 }
 
 workflow fileDumper {
@@ -45,12 +50,19 @@ workflow fileDumper {
 }
 
 workflow loadUserDataset {
-    unpack | loadOntologyFromTabDelim | loadEntityGraph | loadDatasetSpecificAnnotationPropertiesAndGraphs | dumpUserDatasetFiles
-    //loadDatasetSpecificAnnotationPropertiesAndGraphs(Channel.value("READY!"));
+    unpack()
+    loadOntologyFromTabDelim(unpack.out.isaSimpleDir, unpack.out.ontology_terms, unpack.out.ontology_relationships)
+    loadEntityGraph(loadOntologyFromTabDelim.out, unpack.out.isaSimpleDir, unpack.out.ontology_mapping)
+    loadDatasetSpecificAnnotationPropertiesAndGraphs(loadEntityGraph.out)
+    dumpUserDatasetFiles(loadDatasetSpecificAnnotationPropertiesAndGraphs.out)
 }
 
 
 workflow loadBiomUserDataset {
-    //unpack | loadOntologyFromTabDelim | loadEntityGraph | loadDatasetSpecificAnnotationPropertiesAndGraphs | dumpUserDatasetFiles
-    unpackBiom | loadOntologyFromTabDelim | loadEntityGraph | loadDatasetSpecificAnnotationPropertiesAndGraphs | dumpUserDatasetFiles
+    unpackBiom()
+    loadOntologyFromTabDelim(unpackBiom.out.isaSimpleDir, unpackBiom.out.ontology_terms, unpackBiom.out.ontology_relationships)
+    loadEntityGraph(loadOntologyFromTabDelim.out, unpackBiom.out.isaSimpleDir, unpackBiom.out.ontology_mapping)
+    loadDatasetSpecificAnnotationPropertiesAndGraphs(loadEntityGraph.out)
+    dumpUserDatasetFiles(loadDatasetSpecificAnnotationPropertiesAndGraphs.out)
+
 }

--- a/modules/insertStudy.nf
+++ b/modules/insertStudy.nf
@@ -39,6 +39,8 @@ process insertEntityTypeGraph {
     val webDisplayOntologySpec
     val extDBIsReady
     val ontologySpecIsReady
+    val studyDir
+    val ontologyMappingOrOwlFile
 
     output:
     stdout
@@ -162,6 +164,8 @@ process loadDatasetSpecificTables {
 workflow loadEntityGraph {
     take:
     initOntologyOut
+    studyDir
+    ontologyMappingOrOwlFile
 
     main:
 
@@ -169,7 +173,7 @@ workflow loadEntityGraph {
 
     extDbRlsOut = insertExternalDatabaseAndRelease(tuple(databaseName, databaseVersion), initOntologyOut)
 
-    entityGraphOut = insertEntityTypeGraph(extDBRlsSpec, webDisplaySpec, extDbRlsOut, initOntologyOut)
+    entityGraphOut = insertEntityTypeGraph(extDBRlsSpec, webDisplaySpec, extDbRlsOut, initOntologyOut, studyDir, ontologyMappingOrOwlFile)
     attributesOut = loadAttributesAndValues(extDBRlsSpec, webDisplaySpec, entityGraphOut).verbiage
 
     emit:

--- a/modules/templates/insertEntityGraph.bash
+++ b/modules/templates/insertEntityGraph.bash
@@ -68,8 +68,8 @@ fi
 
 # two commas here makes string lower case
 if [ "$params.isaFormat" == "simple" ] ; then
-    internalInvestigationFile="${params.studyDirectory}/${params.investigationBaseName}";
-    internalOntologyMappingFile="--ontologyMappingFile ${params.webDisplayOntologyFile}";
+    internalInvestigationFile="${studyDir}/${params.investigationBaseName}";
+    internalOntologyMappingFile="--ontologyMappingFile ${ontologyMappingOrOwlFile}";
     internalUseIsaSimpleParser="--isSimpleConfiguration ";
 
     if [ "${params.optionalDateObfuscationFile}" != "NA" ] ; then
@@ -89,7 +89,7 @@ ga ApiCommonData::Load::Plugin::InsertEntityGraph \$internalGusConfigFile \$inte
   --commit \\
   --extDbRlsSpec \'$extDbRlsSpec\' \\
   --investigationBaseName $params.investigationBaseName \\
-  --metaDataRoot $params.studyDirectory \\
+  --metaDataRoot $studyDir \\
   --schema $params.schema
 
 stopSingularityInstance

--- a/modules/templates/insertMicrobiomeEntityGraph.bash
+++ b/modules/templates/insertMicrobiomeEntityGraph.bash
@@ -24,12 +24,12 @@ fi
 
 ga ApiCommonData::Load::Plugin::MBioInsertEntityGraph \$internalOntologyMappingOverrideFile \$internalValueMappingFile \$internalIsRelativeAbundance \$internalGusConfigFile \\
   --commit \\
-  --investigationFile "${params.studyDirectory}/${params.investigationBaseName}" \\
-  --sampleDetailsFile "${params.studyDirectory}/${params.sampleDetailsFile}" \\
-  --mbioResultsDir "${params.studyDirectory}/${params.assayResultsDirectory}" \\
+  --investigationFile "${studyDir}/${params.investigationBaseName}" \\
+  --sampleDetailsFile "${studyDir}/${params.sampleDetailsFile}" \\
+  --mbioResultsDir "${studyDir}/${params.assayResultsDirectory}" \\
   --mbioResultsFileExtensions "$params.assayResultsFileExtensionsJson" \\
   --dieOnFirstError 1 \\
-  --ontologyMappingFile $params.webDisplayOntologyFile \\
+  --ontologyMappingFile $ontologyMappingOrOwlFile \\
   --extDbRlsSpec \'$extDbRlsSpec\' \\
   --schema $params.schema \\
   --useOntologyTermTableForTaxonTerms 1

--- a/modules/unpack.nf
+++ b/modules/unpack.nf
@@ -25,6 +25,7 @@ process makeOntologyFiles {
     output:
     path "ontology_terms.txt", emit: ontology_terms
     path "ontology_relationships.txt", emit: ontology_relationships
+    path "${studyDir}/ontologyMapping.xml", emit: ontology_mapping
 
     script:
     """
@@ -59,6 +60,8 @@ process addGeotermsToOntologyFiles {
     output:
     path "ontology_terms.txt", emit: ontology_terms
     path "ontology_relationships.txt", emit: ontology_relationships
+    path "${studyDir}/ontologyMapping.xml", emit: ontology_mapping
+
 
     script:
     """
@@ -75,16 +78,33 @@ process addGeotermsToOntologyFiles {
 }
 
 
+process makeDirectoryForStudies {
+    input:
+    path studyDir
+
+    output:
+    path "isaSimpleDirectory"
+
+    script:
+    """
+    mkdir isaSimpleDirectory
+    mv $studyDir isaSimpleDirectory
+    """
+}
+
+
 workflow unpack {
     main:
 
     parsedStudyDir = makeSimpleFiles();
     ontologyTermsAndRelationships = makeOntologyFiles(parsedStudyDir)
+    isaSimpleDir = makeDirectoryForStudies(parsedStudyDir)
 
     emit:
-    parsedStudyDir
-    ontologyTermsAndRelationships.ontology_terms
-    ontologyTermsAndRelationships.ontology_relationships
+    isaSimpleDir = isaSimpleDir
+    ontology_terms = ontologyTermsAndRelationships.ontology_terms
+    ontology_relationships = ontologyTermsAndRelationships.ontology_relationships
+    ontology_mapping = ontologyTermsAndRelationships.ontology_mapping
 }
 
 
@@ -93,9 +113,11 @@ workflow unpackBiom {
 
     parsedStudyDir = makeSimpleFilesFromParsedBiom();
     ontologyTermsAndRelationships = addGeotermsToOntologyFiles(parsedStudyDir)
+    isaSimpleDir = makeDirectoryForStudies(parsedStudyDir)
 
     emit:
-    parsedStudyDir
-    ontologyTermsAndRelationships.ontology_terms
-    ontologyTermsAndRelationships.ontology_relationships
+    isaSimpleDir = isaSimpleDir
+    ontology_terms = ontologyTermsAndRelationships.ontology_terms
+    ontology_relationships = ontologyTermsAndRelationships.ontology_relationships
+    ontology_mapping = ontologyTermsAndRelationships.ontology_mapping
 }


### PR DESCRIPTION
use inputs/outputs for studyDir/metadataroot and ontologyMapping xml/owl

When using publishdir, files are copied into the specified directory in an asynchronous manner, so they may not be immediately available in the publish directory at the end of the process execution. For this reason, downstream processes should not try to access output files through the publish directory, but through channels.